### PR TITLE
Add META file: enables to locate Unicoq using ocamlfind

### DIFF
--- a/Makefile.local
+++ b/Makefile.local
@@ -1,0 +1,4 @@
+install-extra::
+	install -d "$(OCAMLFIND_DESTDIR)"
+	ln -s $(COQLIBINSTALL)/Unicoq $(OCAMLFIND_DESTDIR)
+	install -m 0644 src/META src/unicoq.a "$(OCAMLFIND_DESTDIR)Unicoq"

--- a/src/META
+++ b/src/META
@@ -1,0 +1,2 @@
+archive(native) = "unicoq.cmxa"
+plugin(native) = "unicoq.cmxs"


### PR DESCRIPTION
so that other plug-ins based on Unicoq (e.g., Mtac2) can be built seamlessly.