### PR TITLE
Revert "Add META file: enables to locate Unicoq using ocamlfind"

### DIFF
--- a/Makefile.local
+++ b/Makefile.local
@@ -1,4 +1,0 @@
-install-extra::
-	install -d "$(OCAMLFIND_DESTDIR)"
-	ln -s $(COQLIBINSTALL)/Unicoq $(OCAMLFIND_DESTDIR)
-	install -m 0644 src/META src/unicoq.a "$(OCAMLFIND_DESTDIR)Unicoq"

--- a/src/META
+++ b/src/META
@@ -1,2 +1,0 @@
-archive(native) = "unicoq.cmxa"
-plugin(native) = "unicoq.cmxs"


### PR DESCRIPTION
As mentioned by @vbgl this breaks the installation if the variable OCAMLFIND_DESTDIR is not present.
Reverts unicoq/unicoq#10