### PR TITLE
Search correctly for `num` library

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,6 +1,0 @@
-FLG -rectypes -thread -w @1..50@59-4 -safe-string
-
-S src
-B src
-
-PKG threads threads.posix coq.intf coq.ltac coq.idetop

--- a/Makefile.local
+++ b/Makefile.local
@@ -1,0 +1,4 @@
+CAMLPKGS += -package num
+
+merlin-hook::
+	$(HIDE)echo 'PKG num' >> .merlin


### PR DESCRIPTION
We fix the way unicoq searches for the `num` library, both when building
and when generating `.merlin`.

We also remove the generated `.merlin` file from the repo. It should not be versioned.

Fixes #22.