### PR TITLE
Add support for primitive canonical projections.

### DIFF
--- a/src/munify.ml
+++ b/src/munify.ml
@@ -908,19 +908,24 @@ module struct
   (** Given a head term c and with arguments l it whd reduces c if it is
       an evar, returning the new head and list of arguments.
   *)
-  let rec decompose_evar sigma (c, l) =
+  let rec decompose_evar env sigma (c, l) =
     let (c', l') = decompose_app sigma c in
     if isCast sigma c' then
       let (t, _, _) = destCast sigma c' in
-      decompose_evar sigma (t, l' @ l)
+      decompose_evar env sigma (t, l' @ l)
+    else if isProj sigma c' then
+      let (pr, record_value) = destProj sigma c' in
+      let app = Retyping.expand_projection env sigma pr record_value l' in
+      let (c', l') = destApp sigma app in
+      c', Array.to_list l'
     else
       (c', l' @ l)
 
   (** {3 "The Function" is split into several} *)
   let rec unify' ?(conv_t=R.CONV) env t t' (dbg, sigma) =
     assert (not (isApp sigma (fst t) || isApp sigma (fst t')));
-    let (c, l as t) = decompose_evar sigma t in
-    let (c', l' as t') = decompose_evar sigma t' in
+    let (c, l as t) = decompose_evar env sigma t in
+    let (c', l' as t') = decompose_evar env sigma t' in
     if !dump then debug_eq env sigma conv_t t t' 0;
     try_conv conv_t env t t' (dbg, sigma) ||= fun dbg ->
       try_hash env t t' (dbg, sigma) &&= fun (dbg, sigma) ->

--- a/test-suite/primitive.v
+++ b/test-suite/primitive.v
@@ -2,17 +2,34 @@ From Unicoq Require Import Unicoq.
 
 Set Primitive Projections.
 
-Record cs := { ty : Type; data : nat }.
-Canonical Structure cs_unit := {| ty := unit; data:=0 |}.
+Module Test1.
 
-(* The definition below used to fail with:
+  Record cs := { ty : Type }.
+  Canonical Structure cs_unit := {| ty := unit |}.
+
+  (* The definition below used to fail with:
 
 Error: In environment
 c := ?c : cs
 The term "tt" has type "unit" while it is expected to have type "ty c".
 
- *)
-Definition x :=
-  let c : cs := _ in
-  let x := (fun (u : ty c) => u) (tt) in
-  data c.
+   *)
+  Definition x :=
+    let c : cs := _ in
+    let x := (fun (u : ty c) => u) (tt) in
+    c.
+
+End Test1.
+
+(* Similar to Test1 but with parameters *)
+Module Test2.
+
+  Record cs (A : Type) := { ty : Type }.
+  Canonical Structure cs_unit {A} : cs A := {| ty := unit |}.
+
+  Definition x :=
+    let c : cs nat := _ in
+    let x := (fun (u : ty _ c) => u) (tt) in
+    c.
+
+End Test2.

--- a/test-suite/primitive.v
+++ b/test-suite/primitive.v
@@ -1,0 +1,18 @@
+From Unicoq Require Import Unicoq.
+
+Set Primitive Projections.
+
+Record cs := { ty : Type; data : nat }.
+Canonical Structure cs_unit := {| ty := unit; data:=0 |}.
+
+(* The definition below used to fail with:
+
+Error: In environment
+c := ?c : cs
+The term "tt" has type "unit" while it is expected to have type "ty c".
+
+ *)
+Definition x :=
+  let c : cs := _ in
+  let x := (fun (u : ty c) => u) (tt) in
+  data c.


### PR DESCRIPTION
This PR seems functional but it is most likely suboptimal:

I use the `Names.Projection.constant` API which is marked as "Don't use this if you don't have to" and I clearly do not have the required knowledge to say if I had to use it.

Additionally, I fear that instantiating universe-polymorphic constants (e.g. a projection constant) with `mkConstant` will be expensive as it will have to create fresh universes. (It seems that primitive projections do not carry universes.)

I suspect that the proper fix would be to distinguish between normal applications and primitive projections wherever the current implementation uses `(EConstr.t * EConstr.t list)`.

Finally, I don't know if the way I added this new case to `decompose_evar` actually covers all the possible combinations of casts and primitive projections.