### PR TITLE
Delete Makefile.local

### DIFF
--- a/Makefile.local
+++ b/Makefile.local
@@ -1,4 +1,0 @@
-CAMLPKGS = $(if $(filter %.cmxa,$@),,-package num)
-
-merlin-hook::
-	$(HIDE)echo 'PKG num' >> .merlin


### PR DESCRIPTION
It seems this file (the first line, anyway) is responsible for unicoq not building on OCaml >=4.08. As far as I can tell, the whole file is unnecessary.

@beta-ziliani any objections? If not we should also delete this file on master.