### PR TITLE
Fix the opam file

### DIFF
--- a/coq-unicoq.opam
+++ b/coq-unicoq.opam
@@ -13,7 +13,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {< "4.08.0"}
+  "ocaml"
   "coq"
 ]
 synopsis: "An enhanced unification algorithm for Coq"


### PR DESCRIPTION
- The package name of Unicoq is different between this repo (`unicoq`) and opam-coq-archive (`coq-unicoq`). This looks like a source of potential issues, e.g., I can easily install two Unicoq in the same OPAM switch.
- I'm using Unicoq in my OPAM switch 4.11.2+flambda and I don't see any problem with it. So I think we can remove the constraint on OCaml.

Also, we probably want to apply the same patch to some of the `master-8.*` branches. 