### PR TITLE
Make the Use Unicoq flag work again

### DIFF
--- a/src/munify.ml
+++ b/src/munify.ml
@@ -1649,7 +1649,12 @@ let instantiate ?(conv_t=C.CONV) ?(options=default_options) env
 
 let use_munify () = !munify_on
 let set_use_munify b =
-  if b then try Evarconv.set_evar_conv unify_new with _ -> ();
+  (* Hack: access to legacy evar_conv_x through evar_unify
+     Ideally, we would have an Evarconv.get_evar_env *)
+  let legacy_evar_conv flags = Evarconv.evar_unify flags TermUnification in
+  let _ = if b then Evarconv.set_evar_conv unify_new
+          else Evarconv.set_evar_conv legacy_evar_conv
+  in
   munify_on := b
 
 let _ = Goptions.declare_bool_option {

--- a/test-suite/munifytest.v
+++ b/test-suite/munifytest.v
@@ -22,8 +22,7 @@ Set Unicoq Super Aggressive.  (* Needs super aggressive option *)
 Definition test3 : (_ : nat -> nat) 0 = 0 := eq_refl.
 
 Unset Use Unicoq.
-(* fails in std coq unif, although the Unset Use Unicoq option is not working*)
-Definition test4 : (_ : nat -> nat) 0 = 0 := eq_refl.
+Fail Definition test4 : (_ : nat -> nat) 0 = 0 := eq_refl.
 Set Use Unicoq.
 
 Unset Unicoq Super Aggressive.


### PR DESCRIPTION
Fixes #56

There is a flag for activating/deactivating Unicoq use that was gave up on after 5b2eb52.

The problem seems to have been that the legacy `evar_conv_x` function actually implemented in `evarconv.ml` can't be  saved properly  before calling `Evarconv.set_evar_conv`, except by [commiting to a fixed `flags` argument](https://github.com/unicoq/unicoq/commit/5b2eb52981224fd867a662fe112d5737073efb6b#diff-92bbdc7df3120be071dd7523dd8b0898a65d922554fb848d97772159fe88da87L115).
Here I use another hack which is to use the `Evarconv.evar_unify` function which does allow to inderectly access the real legacy `evar_conv`. 

This flag is quite useful when testing Unicoq against some big library as it allows to isolate the specific parts that fail.