### PR TITLE
Small refactors

### DIFF
--- a/src/munify.ml
+++ b/src/munify.ml
@@ -27,6 +27,10 @@ module CND = Context.Named.Declaration
 module CRD = Context.Rel.Declaration
 module PE = Pretype_errors
 
+let crd_of_tuple (x,y,z) = match y with
+  | Some y -> CRD.LocalDef(x,y,z)
+  | None   -> CRD.LocalAssum(x,z)
+
 (** {2 Options for unification} *)
 
 (** {3 Enabling Unicoq (implementation at the end)} *)
@@ -1156,7 +1160,7 @@ module struct
 
     (* Lam-Same *)
     | Lambda (name, t1, c1), Lambda (_, t2, c2) ->
-      let env' = EConstr.push_rel (CRD.of_tuple (name, None, t1)) env in
+      let env' = EConstr.push_rel (crd_of_tuple (name, None, t1)) env in
       report (
         log_eq env "Lam-Same" conv_t c c' (dbg, sigma0) &&=
         unify_constr env t1 t2 &&=
@@ -1167,12 +1171,12 @@ module struct
       report (
         log_eq env "Prod-Same" conv_t c c' (dbg, sigma0) &&=
         unify_constr env t1 t2 &&=
-        let env = EConstr.push_rel (CRD.of_tuple (name,None,t1)) env in
+        let env = EConstr.push_rel (crd_of_tuple (name,None,t1)) env in
         unify_constr ~conv_t env c1 c2)
 
     | LetIn (name, trm1, ty1, body1), LetIn (_, trm2, ty2, body2) ->
       (* Let-Same *)
-      let env' = EConstr.push_rel (CRD.of_tuple (name, Some trm1, ty1)) env in
+      let env' = EConstr.push_rel (crd_of_tuple (name, Some trm1, ty1)) env in
       report (
         log_eq env "Let-Same" conv_t c c' (dbg, sigma0) &&=
         unify_constr env trm1 trm2 &&=
@@ -1530,7 +1534,7 @@ module struct
       (dbg, sigma'')
 
   and eta_match conv_t ?(options=default_options) env (name, a, t1) (th, tl as t) (dbg, sigma0 ) =
-    let env' = EConstr.push_rel (CRD.of_tuple (name, None, a)) env in
+    let env' = EConstr.push_rel (crd_of_tuple (name, None, a)) env in
     let t' = applist (lift 1 th, List.map (lift 1) tl @ [mkRel 1]) in
     let ty = Retyping.get_type_of env sigma0 (applist t) in
     check_product dbg env sigma0 ty (name.binder_name, a) &&=

--- a/src/munify.ml
+++ b/src/munify.ml
@@ -179,18 +179,6 @@ let get_stats () = {
 
 
 (** {2 Generic utility functions} *)
-let _array_mem_from_i e i a =
-  let j = ref i in
-  let length = Array.length a in
-  let b = ref false in
-  while !j < length && not !b do
-    if a.(!j) = e then
-      b := true
-    else
-      j := !j+1
-  done;
-  !b
-
 let array_mem_to_i e i a =
   let j = ref 0 in
   let b = ref false in
@@ -345,17 +333,6 @@ let is_lift env sigma c =
 (** Given a named_context returns a list with its variables *)
 let id_substitution nc =
   List.fold_right (fun d s -> mkVar (CND.get_id d) :: s) nc []
-
-(** Pre: isVar v1 *)
-let _is_same_var sigma v1 v2 = isVar sigma v2 && (destVar sigma v1 = destVar sigma v2)
-
-(** Pre: isRel v1 *)
-let _is_same_rel sigma v1 v2 = isRel sigma v2 && destRel sigma v1 = destRel sigma v2
-
-let _is_same_evar sigma i1 ev2 =
-  match kind sigma ev2 with
-  | Evar (i2, _) -> i1 = i2
-  | _ -> false
 
 let isVarOrRel sigma c = isVar sigma c || isRel sigma c
 

--- a/src/munify.ml
+++ b/src/munify.ml
@@ -178,23 +178,6 @@ let get_stats () = {
 }
 
 
-(** {2 Functions borrowed from Coq 8.4 and not found in 8.5} *)
-(* Note: let-in contributes to the instance *)
-let make_evar_instance sigma sign args =
-  let rec instrec = function
-    | def :: sign, c::args when isVarId sigma (CND.get_id def) c -> instrec (sign,args)
-    | def :: sign, c::args -> (CND.get_id def,c) :: instrec (sign,args)
-    | [],[] -> []
-    | [],_ | _,[] -> anomaly (str"Signature and its instance do not match")
-  in
-  instrec (sign,args)
-
-let instantiate_evar sigma sign c args =
-  let inst = make_evar_instance sigma sign args in
-  if inst = [] then c else replace_vars sigma inst c
-(** Not in 8.5 *)
-
-
 (** {2 Generic utility functions} *)
 let _array_mem_from_i e i a =
   let j = ref i in
@@ -849,8 +832,10 @@ module Inst = functor (U : Unifier) -> struct
 	      Some (dir == Original)
 	   else None)
             env sigma t' in
-      let t'' = instantiate_evar sigma nc t' subsl in
-      (* XXX: EConstr.API *)
+      let evi = Evd.find_undefined sigma ev in
+      let t'' =
+        Evd.instantiate_evar_array sigma evi t' (SList.of_full_list subsl)
+      in
       let ty = Evd.existential_type sigma (ev,subs) in
       let unifty =
 	try

--- a/src/munify.ml
+++ b/src/munify.ml
@@ -1524,9 +1524,9 @@ module struct
     let nc' = EConstr.push_named_context_val ProofVar (CND.of_tuple (Context.make_annot naid ERelevance.relevant, None, a)) nc in
     let sigma', univ = Evd.new_sort_variable Evd.univ_flexible sigma in
     let sigma'',v = Evarutil.new_pure_evar ~typeclass_candidate:false nc' sigma' ~relevance:ERelevance.relevant (EConstr.mkSort univ) in
-    let idsubst = (mkRel 1 :: id_substitution (Environ.named_context_of_val nc)) in
+    let idsubst = SList.cons (mkRel 1) (EConstr.identity_subst_val nc) in
     unify_constr ~conv_t:C.CUMUL env ty
-      (mkProd (Context.make_annot (Names.Name naid) ERelevance.relevant, a, mkLEvar sigma'' (v, idsubst)))
+      (mkProd (Context.make_annot (Names.Name naid) ERelevance.relevant, a, mkEvar (v, idsubst)))
       (dbg, sigma'')
 
   and eta_match conv_t ?(options=default_options) env (name, a, t1) (th, tl as t) (dbg, sigma0 ) =

--- a/src/munify.ml
+++ b/src/munify.ml
@@ -541,10 +541,13 @@ let rec prune sigma (ev, plist) =
   let evi = Evd.find_undefined sigma ev in
   let env = Evd.evar_filtered_hyps evi in
   let env' = remove sigma (EConstr.named_context_of_val env) plist in
-  let env_val' = (List.fold_right (fun d acc ->
-      push_named_context_val (Environ.var_status_ctxt (CND.get_id d) env) d acc)
-      env'
-      Environ.empty_named_context_val)
+  let kept =
+    List.fold_left (fun ids d -> Id.Set.add (CND.get_id d) ids) Id.Set.empty env'
+  in
+  let filter =
+    Evd.Filter.apply_subfilter (Evd.evar_filter evi)
+      (List.map (fun d -> Id.Set.mem (CND.get_id d) kept)
+         (EConstr.named_context_of_val env))
   in
   (* the type of the evar may contain an evar depending on the some of
      the vars that we want to prune, so we need to prune that
@@ -555,10 +558,7 @@ let rec prune sigma (ev, plist) =
       None -> raise CannotPrune
     | Some (m, concl) ->
       let sigma = prune_all m sigma in
-      let concl = Evd.evar_concl evi in
-      let typeclass_candidate = Evd.is_typeclass_evar sigma ev in
-      let sigma, ev' = EU.new_pure_evar ~typeclass_candidate env_val' sigma ~relevance:(Evd.evar_relevance evi) concl in
-      Evd.define ev (mkLEvar sigma (ev', id_env')) sigma
+      fst (Evd.restrict ev filter sigma)
 
 and prune_all map sigma =
   List.fold_left prune sigma (Evar.Map.bindings map)

--- a/src/munify.ml
+++ b/src/munify.ml
@@ -397,7 +397,8 @@ let get_definition sigma env t : EConstr.t =
       | _ -> anomaly (str"get_definition for rel didn't have definition!")
   else if isConst sigma t then
     let c,i = destConst sigma t in
-    of_constr @@ Environ.constant_value_in env (c, EInstance.kind sigma i)
+    EConstr.constant_value_in env sigma
+      (c, EInstance.make (EInstance.kind sigma i))
   else
     anomaly (str"get_definition didn't have definition!")
 

--- a/src/munify.ml
+++ b/src/munify.ml
@@ -27,10 +27,6 @@ module CND = Context.Named.Declaration
 module CRD = Context.Rel.Declaration
 module PE = Pretype_errors
 
-let crd_of_tuple (x,y,z) = match y with
-  | Some y -> CRD.LocalDef(x,y,z)
-  | None   -> CRD.LocalAssum(x,z)
-
 (** {2 Options for unification} *)
 
 (** {3 Enabling Unicoq (implementation at the end)} *)
@@ -1199,7 +1195,7 @@ module struct
 
     (* Lam-Same *)
     | Lambda (name, t1, c1), Lambda (_, t2, c2) ->
-      let env' = EConstr.push_rel (crd_of_tuple (name, None, t1)) env in
+      let env' = EConstr.push_rel (CRD.of_tuple (name, None, t1)) env in
       report (
         log_eq env "Lam-Same" conv_t c c' (dbg, sigma0) &&=
         unify_constr env t1 t2 &&=
@@ -1210,12 +1206,12 @@ module struct
       report (
         log_eq env "Prod-Same" conv_t c c' (dbg, sigma0) &&=
         unify_constr env t1 t2 &&=
-        let env = EConstr.push_rel (crd_of_tuple (name,None,t1)) env in
+        let env = EConstr.push_rel (CRD.of_tuple (name,None,t1)) env in
         unify_constr ~conv_t env c1 c2)
 
     | LetIn (name, trm1, ty1, body1), LetIn (_, trm2, ty2, body2) ->
       (* Let-Same *)
-      let env' = EConstr.push_rel (crd_of_tuple (name, Some trm1, ty1)) env in
+      let env' = EConstr.push_rel (CRD.of_tuple (name, Some trm1, ty1)) env in
       report (
         log_eq env "Let-Same" conv_t c c' (dbg, sigma0) &&=
         unify_constr env trm1 trm2 &&=
@@ -1573,7 +1569,7 @@ module struct
       (dbg, sigma'')
 
   and eta_match conv_t ?(options=default_options) env (name, a, t1) (th, tl as t) (dbg, sigma0 ) =
-    let env' = EConstr.push_rel (crd_of_tuple (name, None, a)) env in
+    let env' = EConstr.push_rel (CRD.of_tuple (name, None, a)) env in
     let t' = applist (lift 1 th, List.map (lift 1) tl @ [mkRel 1]) in
     let ty = Retyping.get_type_of env sigma0 (applist t) in
     check_product dbg env sigma0 ty (name.binder_name, a) &&=

--- a/src/munify.ml
+++ b/src/munify.ml
@@ -232,8 +232,6 @@ let report (l, s) =
   | ES.Success sigma -> success (l, sigma)
   | ES.UnifFailure (sigma, _) -> err (l, sigma)
 
-let is_success s = match s with ES.Success _ -> true | _ -> false
-
 (** {3 Monadic style operations for the unif type} *)
 let (&&=) (l, s as opt) f =
   match s with
@@ -983,7 +981,7 @@ module struct
               ||= cont conv_t env t t' sigma
             end
         in
-        if not (is_success (snd res)) && use_hash () then
+        if not (ES.is_success (snd res)) && use_hash () then
           Hashtbl.add tbl (sigma, env, t, t') true;
         res
 
@@ -1096,7 +1094,7 @@ module struct
           in
           let rule = if b then "Meta-Same" else "Meta-Same-Same" in
           log_eq_spine env rule conv_t t t' (dbg, sigma) &&= fun (dbg, sigma) ->
-            if is_success (snd p) then
+            if ES.is_success (snd p) then
               report (ise_list2 (unify_constr env) l l' (dbg, sigma))
             else
               report (dbg, ES.UnifFailure (sigma, PE.NotSameHead))

--- a/src/munify.ml
+++ b/src/munify.ml
@@ -708,7 +708,7 @@ let evar_apprec ts env sigma (c, stack) =
   in aux (c, RO.Stack.append_app_list stack RO.Stack.empty)
 
 let eq_app_stack sigma (c, l) (c', l') =
-  eq_constr sigma c c' && List.for_all2 (eq_constr sigma) l l'
+  eq_constr sigma c c' && CList.for_all2eq (eq_constr sigma) l l'
 
 let remove_non_var env sigma (ev, subs as evsubs) args =
   let subs = Array.of_list subs in


### PR DESCRIPTION
This is an AI-assisted refactor to clean a bit the code, avoiding repeating code that is in Rocq's API. Each commit contains a small change, so they can be reviewed in isolation:

 * 6370eb6ef36d622d57efd7467aaeb7bb1555c6e4 requires a change in Rocq's API, so it was reverted in e9784bf73a7437b453b4a416f38ea60ecfc3d375.
 * 5e639796dcd74d6af21ba320db1e0cf6e6c0467a removes code intended to compile with an old version from Rocq, that for instantiating an evar.
 * 13738eee2563cfd25efdd5e28f9669a7edeb992e removes an utility already existing in Rocq.
 * 857ac9c163c29784168662eb611729a04a8cb155 was a surprise: it replaces a raising function for function comparison with an utility that just return false if the length of the lists is not the same.
 * 7c6b5b4b249827b81f1e151502cd60facf4bf7f8 just cleans up some code.
 * a1adf943f6b2c14d17f81a04d065c1558f34745e uses Rocq's evar's restriction to prune the local context on an evar.
 * 639e681fae732901b661dc4b06c5ee58fa56f644 smells OK but I'm not sure if it's really necessary.
 * e0b90a4ba919f4f7c63894796d64d338d75df072 same as previous one, it replaces the way to construct an identity substitution with Rocq's own.